### PR TITLE
Use headless opencv library by default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ dependencies = [
     "pandas == 2.*",
     "scikit-learn == 1.*",
     "scikit-image == 0.24.0",
-    "opencv-python == 4.*",
+    "opencv-python-headless == 4.*",
     "matplotlib == 3.*",
     "joblib == 1.*",
     "tqdm == 4.*",


### PR DESCRIPTION
When installing `eyened-platform` which depends on this package, we get 2 opencv packages installed at the same time, which is explicitly NOT recommended by OpenCV, as they share the same `cv2` import namespace:

- `opencv-python-headless`, coming from the eyened-orm
- `opencv-python`, coming from this package

I don't see any code in the repo that requires the non-headless variant (correct me if i'm wrong). So I propose to depend on the 'headless' variant, which is smaller and has less OS dependencies.

For details, see: https://github.com/opencv/opencv-python/blob/4.x/README.md#installation-and-usage

NB I did some research on doing a 'one or these 2 (or more) packages is required' to allow listing both packages, but `pyproject.toml` doesn't have a clean way to do this, other than making both packages optional.